### PR TITLE
Add `convert-manifest` command

### DIFF
--- a/__snapshots__/babel.js
+++ b/__snapshots__/babel.js
@@ -22,10 +22,7 @@ exports['babel config'] = {
         ]
       ],
       "plugins": [
-        "@babel/plugin-transform-modules-commonjs",
         "module:babel-plugin-add-module-exports",
-        "module:babel-plugin-transform-es3-member-expression-literals",
-        "module:babel-plugin-transform-es3-property-literals",
         [
           "module:babel-plugin-import-redirect",
           {

--- a/commands/convert-manifest.js
+++ b/commands/convert-manifest.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import * as npm from "../lib/npm.js"
+import {EOL} from "os"
+export let command = "convert-manifest"
+export let desc =
+	"read a bower manifest on stdin and write a npm manifest to stdout"
+
+export let builder = yargs =>
+	yargs
+		.option("semver", {
+			describe: "the version number to use in the package.json",
+			type: "string",
+			required: true
+		})
+		.option("include-babel-config", {
+			describe: "whether or not to include babel config in the package.json",
+			type: "boolean",
+			default: false
+		})
+
+let {
+	stdin,
+	stdout
+} = process
+
+export let handler = async function ဪ(argv) {
+	let input = ""
+
+	stdin.resume()
+	stdin.setEncoding("utf-8")
+
+	stdin.on("data", chunk => input += chunk)
+
+	stdin.on("end", async () => {
+		let bowerManifest= JSON.parse(input)
+		bowerManifest.version = argv.semver
+		let npmManifest = await npm.createManifest(bowerManifest)
+		if (!argv.includeBabelConfig) {
+			delete npmManifest.babel
+		}
+		stdout.write(JSON.stringify(npmManifest, null, "\t") + EOL)
+	})
+}

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -123,20 +123,9 @@ export let createDependencyVersion = async ([name, version]) => {
 	)
 }
 
-let stringifyDependency = ([name, version]) => {
-	return JSON.stringify({[name]: version})
-}
-
-let logChange = (one, two) =>
-	log(
-		chalk.gray(`${stringifyDependency(one)} -> ${stringifyDependency(two)}`)
-	)
-
 export let createDependency = async ([name, version]) => {
 	let npmName = await createDependencyName(name)
 	let npmVersion = await createDependencyVersion([name, version])
-
-	logChange([name, version], [npmName, npmVersion])
 
 	return [npmName, npmVersion]
 }
@@ -185,8 +174,6 @@ export let createManifest = async bowerManifest => {
 	let npmName = createComponentName(name)
 	let npmDependencies =
 		dependencies && (await createDependencies(entries(dependencies)))
-
-	log(chalk.cyan(`creating ${name}@${version} as ${npmName}@${version}`))
 
 	return {
 		...skeleton,


### PR DESCRIPTION
It takes a bower manifest on stdin and prints a npm manifest on stdout

this:

```shell
cat <<END | node . convert-manifest --semver=7.0.9
{
  "name": "o-table",
  "dependencies": {
    "o-colors": "^4.0.0",
    "o-grid": "^4.0.6",
    "o-icons": ">=4.0.0 <6",
    "o-typography": "^5.0.0",
    "o-brand": "^3.1.1",
    "o-visual-effects": "^2.0.3",
    "o-buttons": "^5.14.0",
    "dom-delegate": "ftdomdelegate#^2.2.0"
  },
  "main": [
    "main.scss",
    "main.js"
  ],
  "ignore": [
    ".gitignore",
    "build",
    "test",
    "karma.conf.js",
    "package.json"
  ]
}
END
```

prints:

```json
{
	"name": "@financial-times/o-table",
	"version": "7.0.9",
	"component": "o-table",
	"browser": "browser.js",
	"scripts": {},
	"files": [
		"svg/",
		"dist/",
		"index.js",
		"src/",
		"main*",
		"img",
		"*.json",
		"scss",
		"!bower.json",
		"!.bower.json"
	],
	"eslintIgnore": [
		"index.js",
		"dist/"
	],
	"dependencies": {
		"@financial-times/o-colors": "^4.0.0",
		"@financial-times/o-grid": "^4.0.6",
		"@financial-times/o-icons": ">=4.0.0 <6",
		"@financial-times/o-typography": "^5.0.0",
		"@financial-times/o-brand": "^3.1.1",
		"@financial-times/o-visual-effects": "^2.0.3",
		"@financial-times/o-buttons": "^5.14.0",
		"dom-delegate": "^2.2.0"
	}
}
```


yeet