### PR TITLE
Compile down only as far as javascript

### DIFF
--- a/__snapshots__/babel.js
+++ b/__snapshots__/babel.js
@@ -22,7 +22,7 @@ exports['babel config'] = {
             "targets": {
               "esmodules": true
             },
-            "modules": "auto"
+            "modules": "commonjs"
           }
         ]
       ],

--- a/__snapshots__/babel.js
+++ b/__snapshots__/babel.js
@@ -1,8 +1,9 @@
 exports['babel config'] = {
+  "filename": "",
   "presets": [],
   "plugins": [
     [
-      "module:babel-plugin-module-resolver",
+      "~root~/node_modules/babel-plugin-module-resolver",
       {
         "alias": {
           "alice": "banana",
@@ -15,16 +16,20 @@ exports['babel config'] = {
     {
       "presets": [
         [
-          "@babel/preset-env",
+          "~root~/node_modules/@babel/preset-env",
           {
-            "useBuiltIns": false
+            "useBuiltIns": false,
+            "targets": {
+              "esmodules": true
+            },
+            "modules": "auto"
           }
         ]
       ],
       "plugins": [
-        "module:babel-plugin-add-module-exports",
+        "~root~/node_modules/babel-plugin-add-module-exports",
         [
-          "module:babel-plugin-import-redirect",
+          "~root~/node_modules/babel-plugin-import-redirect",
           {
             "redirect": {
               "alice/src/(.*)": "banana/dist/$1",
@@ -39,8 +44,9 @@ exports['babel config'] = {
     {
       "presets": [],
       "plugins": [
+        "~root~/node_modules/babel-plugin-add-module-exports",
         [
-          "module:babel-plugin-import-redirect",
+          "~root~/node_modules/babel-plugin-import-redirect",
           {
             "redirect": {
               "./src/(.*)": "./dist/$1",
@@ -57,13 +63,13 @@ exports['babel config'] = {
       "presets": [],
       "plugins": [
         [
-          "module:babel-plugin-import-redirect",
+          "~root~/node_modules/babel-plugin-import-redirect",
           {
             "root": "test",
             "redirect": {
               "../src/(.*)": "../dist/$1",
               "./fixture/main": "./fixture/main",
-              "../main": "../browser.js",
+              "../main": "../browser",
               "alice/src/(.*)": "banana/dist/$1",
               "charlie/src/(.*)": "delta/dist/$1"
             },

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -56,7 +56,7 @@ function getModulePath (moduleName) {
  */
 export function createConfiguration ({
 	aliases,
-	modules = "auto",
+	modules = "commonjs",
 	filename = ""
 }) {
 	return {

--- a/test/lib/babel.js
+++ b/test/lib/babel.js
@@ -1,13 +1,19 @@
 import snap from "snap-shot-it"
-import * as babel from "../../lib/babel"
+import mock from "mock-require"
 
 describe("babel suite", () => {
 	it("returns the same babel config", () => {
+		mock("../../lib/root", {
+			resolve: (...paths) =>
+				"~root~/" + paths.join("/")
+		})
+		let babel = mock.reRequire("../../lib/babel")
 		snap("babel config", babel.createConfiguration({
 			aliases: {
 				"alice": "banana",
 				"charlie": "delta"
 			}
 		}))
+		mock.stopAll()
 	})
 })


### PR DESCRIPTION
also builds `.mjs` files that don't compile the import/export to commonjs.

there's a bug in the `browser.mjs` file where it imports `.js` directly, but the rest of them are fine.